### PR TITLE
Create liquid glass portfolio experience

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,649 @@
+:root {
+  --background: #05070f;
+  --foreground: rgba(255, 255, 255, 0.88);
+  --muted: rgba(255, 255, 255, 0.64);
+  --accent: linear-gradient(120deg, #87f0ff, #d68cff, #8c96ff);
+  --surface: rgba(17, 24, 39, 0.55);
+  --surface-border: rgba(255, 255, 255, 0.12);
+  --shadow: 0 20px 50px rgba(10, 20, 40, 0.6);
+  --glass-blur: blur(24px);
+  --max-width: 1200px;
+  --transition: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme="light"] {
+  --background: #f7f9fc;
+  --foreground: rgba(20, 24, 40, 0.92);
+  --muted: rgba(20, 24, 40, 0.7);
+  --surface: rgba(255, 255, 255, 0.66);
+  --surface-border: rgba(20, 24, 40, 0.1);
+  --shadow: 0 18px 40px rgba(86, 98, 128, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: var(--background);
+  color: var(--foreground);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+.background {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  z-index: -1;
+}
+
+.orb {
+  position: absolute;
+  width: 480px;
+  height: 480px;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.55;
+  transform: translate3d(0, 0, 0);
+  mix-blend-mode: screen;
+}
+
+.orb--one {
+  background: radial-gradient(circle at 30% 30%, #87f0ff, rgba(135, 240, 255, 0));
+  top: -140px;
+  left: -120px;
+}
+
+.orb--two {
+  background: radial-gradient(circle at 40% 40%, #d68cff, rgba(214, 140, 255, 0));
+  bottom: -120px;
+  right: -160px;
+}
+
+.orb--three {
+  background: radial-gradient(circle at 70% 70%, #8c96ff, rgba(140, 150, 255, 0));
+  top: 40%;
+  left: 50%;
+}
+
+.grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 120px 120px;
+  mask-image: radial-gradient(circle at center, rgba(0, 0, 0, 0.5), transparent 70%);
+}
+
+.navigation {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 24px clamp(20px, 5vw, 48px);
+  z-index: 10;
+  mix-blend-mode: difference;
+  color: #f7f9fc;
+}
+
+.navigation__logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.navigation__links {
+  display: flex;
+  gap: 24px;
+  font-size: 0.95rem;
+}
+
+.navigation__links a {
+  opacity: 0.8;
+  transition: opacity 250ms var(--transition);
+}
+
+.navigation__links a:hover,
+.navigation__links a:focus-visible,
+.navigation__links a.active {
+  opacity: 1;
+}
+
+.navigation__menu {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(5, 7, 15, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 250ms var(--transition), border 250ms var(--transition);
+}
+
+.navigation__menu:hover,
+.navigation__menu:focus-visible,
+.navigation__menu[aria-expanded="true"] {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.navigation__menu-icon {
+  display: inline-block;
+  width: 18px;
+  height: 2px;
+  background: currentColor;
+  position: relative;
+  border-radius: 999px;
+}
+
+.navigation__menu-icon::before,
+.navigation__menu-icon::after {
+  content: "";
+  position: absolute;
+  width: 18px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 999px;
+  transition: transform 300ms ease, opacity 300ms ease;
+}
+
+.navigation__menu-icon::before {
+  transform: translateY(-6px);
+}
+
+.navigation__menu-icon::after {
+  transform: translateY(6px);
+}
+
+.navigation__menu[aria-expanded="true"] .navigation__menu-icon {
+  background: transparent;
+}
+
+.navigation__menu[aria-expanded="true"] .navigation__menu-icon::before {
+  transform: rotate(45deg);
+}
+
+.navigation__menu[aria-expanded="true"] .navigation__menu-icon::after {
+  transform: rotate(-45deg);
+}
+
+.mobile-nav {
+  position: absolute;
+  top: calc(100% + 16px);
+  right: 24px;
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px;
+  border-radius: 24px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--shadow);
+  min-width: 220px;
+}
+
+.mobile-nav a {
+  font-size: 1rem;
+  color: var(--foreground);
+  opacity: 0.85;
+}
+
+.mobile-nav a:hover,
+.mobile-nav a:focus-visible,
+.mobile-nav a.active {
+  opacity: 1;
+}
+
+.mobile-nav.is-open {
+  display: flex;
+}
+
+.theme-toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(16px);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 300ms var(--transition), background 300ms var(--transition);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-2px);
+}
+
+.theme-toggle--active {
+  animation: pulse 500ms ease;
+}
+
+.theme-toggle__icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #fef08a, #f97316, #facc15);
+  box-shadow: 0 0 20px rgba(250, 204, 21, 0.6);
+}
+
+body[data-theme="light"] .theme-toggle__icon {
+  background: linear-gradient(135deg, #1e293b, #0f172a, #1e40af);
+  box-shadow: 0 0 20px rgba(59, 130, 246, 0.4);
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 40px clamp(20px, 5vw, 48px) 120px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: stretch;
+  margin-top: 60px;
+}
+
+.hero__content {
+  padding: clamp(32px, 5vw, 48px);
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.1;
+  margin-bottom: 16px;
+}
+
+.hero p {
+  font-size: 1.05rem;
+  color: var(--muted);
+}
+
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 28px 0;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(80px, 1fr));
+  gap: 20px;
+  text-align: center;
+}
+
+.hero__stats dt {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.hero__stats dd {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero__portrait {
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 48px;
+}
+
+.portrait__glow {
+  position: absolute;
+  inset: 18px;
+  border-radius: 24px;
+  background: linear-gradient(150deg, rgba(135, 240, 255, 0.8), rgba(214, 140, 255, 0.5));
+  filter: blur(24px);
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.portrait__inner {
+  position: relative;
+  padding: 48px 32px;
+  border-radius: 24px;
+  background: rgba(5, 7, 15, 0.7);
+  text-align: center;
+  z-index: 1;
+}
+
+.portrait__inner h2 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+
+.section {
+  margin-top: 120px;
+}
+
+.section__header {
+  max-width: 620px;
+  margin-bottom: 36px;
+}
+
+.section__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.section__eyebrow::before {
+  content: "";
+  display: inline-block;
+  width: 32px;
+  height: 1px;
+  background: var(--muted);
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  margin: 12px 0 0;
+}
+
+.section__content {
+  display: grid;
+  gap: 24px;
+}
+
+.pill-list {
+  list-style: none;
+  margin: 28px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.pill-list li {
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+}
+
+.timeline {
+  display: grid;
+  gap: 28px;
+}
+
+.timeline__item {
+  display: grid;
+  gap: 12px;
+  padding: 32px;
+}
+
+.timeline__item time {
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.timeline__item ul {
+  margin: 12px 0 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.project-card {
+  display: grid;
+  gap: 20px;
+  padding: 32px;
+}
+
+.project-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.testimonial-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.testimonial blockquote {
+  margin: 0 0 24px;
+  font-size: 1.05rem;
+}
+
+.testimonial figcaption {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.section--split {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.2fr);
+  gap: 36px;
+  align-items: start;
+}
+
+.contact-form {
+  display: grid;
+  gap: 20px;
+  padding: 36px;
+}
+
+.form-group {
+  display: grid;
+  gap: 8px;
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+textarea {
+  font: inherit;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(5, 7, 15, 0.4);
+  color: var(--foreground);
+  transition: border 200ms ease, box-shadow 200ms ease;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(135, 240, 255, 0.6);
+  box-shadow: 0 0 0 3px rgba(135, 240, 255, 0.2);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 24px;
+  border-radius: 999px;
+  background-image: var(--accent);
+  color: #05070f;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 250ms var(--transition), box-shadow 250ms var(--transition);
+  box-shadow: 0 16px 40px rgba(135, 240, 255, 0.25);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 50px rgba(135, 240, 255, 0.35);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--foreground);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: none;
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+.glass {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 28px;
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.glass::before {
+  content: "";
+  position: absolute;
+  inset: -120px;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.35), transparent 60%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.footer {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 60px clamp(20px, 5vw, 48px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.footer__links {
+  display: flex;
+  gap: 20px;
+}
+
+@media (max-width: 768px) {
+  .navigation {
+    padding: 16px 24px;
+    backdrop-filter: blur(18px);
+    mix-blend-mode: normal;
+    color: var(--foreground);
+  }
+
+  .navigation__links {
+    display: none;
+  }
+
+  .navigation__menu {
+    display: inline-flex;
+  }
+
+  .mobile-nav {
+    right: 16px;
+  }
+
+  .hero {
+    margin-top: 20px;
+  }
+
+  .section {
+    margin-top: 80px;
+  }
+
+  .hero__stats {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+
+  .section--split {
+    grid-template-columns: 1fr;
+  }
+
+  .footer {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,80 @@
+const body = document.body;
+const themeToggle = document.querySelector('.theme-toggle');
+const navLinks = document.querySelectorAll('.navigation__links a');
+const mobileMenuButton = document.querySelector('.navigation__menu');
+const mobileNav = document.querySelector('.mobile-nav');
+const mobileLinks = document.querySelectorAll('.mobile-nav a');
+const yearEl = document.getElementById('year');
+
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const savedTheme = localStorage.getItem('theme');
+
+if (savedTheme) {
+  body.setAttribute('data-theme', savedTheme);
+} else if (!prefersDark.matches) {
+  body.setAttribute('data-theme', 'light');
+}
+
+prefersDark.addEventListener('change', (event) => {
+  if (!localStorage.getItem('theme')) {
+    body.setAttribute('data-theme', event.matches ? 'dark' : 'light');
+  }
+});
+
+themeToggle?.addEventListener('click', () => {
+  const currentTheme = body.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+  body.setAttribute('data-theme', currentTheme);
+  localStorage.setItem('theme', currentTheme);
+  themeToggle.classList.add('theme-toggle--active');
+  setTimeout(() => themeToggle.classList.remove('theme-toggle--active'), 500);
+});
+
+const closeMobileNav = () => {
+  mobileNav?.classList.remove('is-open');
+  mobileMenuButton?.setAttribute('aria-expanded', 'false');
+};
+
+mobileMenuButton?.addEventListener('click', () => {
+  const isOpen = mobileNav?.classList.toggle('is-open');
+  mobileMenuButton.setAttribute('aria-expanded', String(Boolean(isOpen)));
+});
+
+mobileLinks.forEach((link) =>
+  link.addEventListener('click', () => {
+    closeMobileNav();
+  })
+);
+
+document.addEventListener('click', (event) => {
+  if (
+    mobileNav &&
+    mobileMenuButton &&
+    !mobileNav.contains(event.target) &&
+    !mobileMenuButton.contains(event.target)
+  ) {
+    closeMobileNav();
+  }
+});
+
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      const id = entry.target.getAttribute('id');
+      if (entry.isIntersecting && id) {
+        navLinks.forEach((link) => {
+          const isActive = link.getAttribute('href') === `#${id}`;
+          link.classList.toggle('active', isActive);
+        });
+        mobileLinks.forEach((link) => {
+          const isActive = link.getAttribute('href') === `#${id}`;
+          link.classList.toggle('active', isActive);
+        });
+      }
+    });
+  },
+  { rootMargin: '-50% 0px -45% 0px' }
+);
+
+document.querySelectorAll('section[id]').forEach((section) => observer.observe(section));
+
+yearEl.textContent = new Date().getFullYear();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Liquid Glass Portfolio | Human-Centered Product Designer</title>
+    <meta
+      name="description"
+      content="A human-centric product designer crafting immersive experiences with a liquid glass aesthetic."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <div class="background" aria-hidden="true">
+      <div class="orb orb--one"></div>
+      <div class="orb orb--two"></div>
+      <div class="orb orb--three"></div>
+      <div class="grid"></div>
+    </div>
+
+    <header class="navigation" id="top">
+      <a class="navigation__logo" href="#top">Ivy Morrow</a>
+      <nav class="navigation__links" aria-label="Primary navigation">
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#projects">Projects</a>
+        <a href="#testimonials">Testimonials</a>
+        <a href="#contact">Contact</a>
+      </nav>
+      <button class="navigation__menu" aria-expanded="false" aria-controls="mobile-nav">
+        <span class="navigation__menu-label">Menu</span>
+        <span class="navigation__menu-icon" aria-hidden="true"></span>
+      </button>
+      <button class="theme-toggle" aria-label="Toggle theme">
+        <span class="theme-toggle__icon" aria-hidden="true"></span>
+      </button>
+      <nav id="mobile-nav" class="mobile-nav" aria-label="Mobile navigation">
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#projects">Projects</a>
+        <a href="#testimonials">Testimonials</a>
+        <a href="#contact">Contact</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="hero__content glass">
+          <h1 id="hero-title">Designing fluid experiences for curious humans.</h1>
+          <p>
+            I'm Ivy, a product designer weaving research, strategy, and delightful
+            interactions into inclusive digital ecosystems. My work blends
+            neuroaesthetics with accessibility to craft memorable products for
+            ambitious teams.
+          </p>
+          <div class="hero__cta">
+            <a class="button" href="#projects">View Work</a>
+            <a class="button button--ghost" href="#contact">Schedule a Call</a>
+          </div>
+          <dl class="hero__stats" aria-label="Key achievements">
+            <div>
+              <dt>9 yrs</dt>
+              <dd>Design Leadership</dd>
+            </div>
+            <div>
+              <dt>42%</dt>
+              <dd>Avg. Conversion Lift</dd>
+            </div>
+            <div>
+              <dt>18M+</dt>
+              <dd>Users Impacted</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="hero__portrait glass" role="img" aria-label="Illustration of Ivy">
+          <div class="portrait__glow"></div>
+          <div class="portrait__inner">
+            <h2>Product Designer</h2>
+            <p>Shaping adaptive products through empathy, evidence, and craft.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="about" class="section">
+        <div class="section__header">
+          <span class="section__eyebrow">About</span>
+          <h2>Designing with radical empathy</h2>
+        </div>
+        <div class="section__content">
+          <article class="glass">
+            <p>
+              I specialize in systems thinking, conversational design, and
+              behavior-driven experimentation. My practice orbits the belief that
+              every interaction should feel like a small act of care. From
+              facilitating discovery sprints to crafting micro-interactions, my
+              aim is to make the complex effortlessly useful.
+            </p>
+            <p>
+              Beyond pixels, I coach cross-functional teams on inclusive rituals,
+              evidence-based decisions, and storytelling that sticks.
+            </p>
+            <ul class="pill-list" aria-label="Core capabilities">
+              <li>Inclusive Research</li>
+              <li>Design Systems</li>
+              <li>Product Strategy</li>
+              <li>Service Blueprints</li>
+              <li>Creative Facilitation</li>
+              <li>Immersive Prototyping</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="experience" class="section">
+        <div class="section__header">
+          <span class="section__eyebrow">Experience</span>
+          <h2>Moments that shaped my craft</h2>
+        </div>
+        <div class="timeline">
+          <article class="timeline__item glass">
+            <time dateTime="2021">2021 — Present</time>
+            <h3>Director of Product Design · Lumen Labs</h3>
+            <p>
+              Leading a multi-disciplinary team to redesign the mental health
+              journey for 11M+ members, with a focus on adaptive personalization
+              and clinical rigor.
+            </p>
+            <ul>
+              <li>Launched a responsive design system across 5 product lines.</li>
+              <li>Introduced ethical research playbooks adopted company-wide.</li>
+            </ul>
+          </article>
+
+          <article class="timeline__item glass">
+            <time dateTime="2018">2018 — 2021</time>
+            <h3>Senior Product Designer · Atlas</h3>
+            <p>
+              Reimagined the onboarding journey for a global fintech platform,
+              increasing customer activation by 52% through micro-personalization.
+            </p>
+            <ul>
+              <li>Prototyped immersive finance education experiences in AR.</li>
+              <li>Built a multi-language accessibility workflow with engineering.</li>
+            </ul>
+          </article>
+
+          <article class="timeline__item glass">
+            <time dateTime="2014">2014 — 2018</time>
+            <h3>Product Designer · Northbound</h3>
+            <p>
+              Crafted data-informed products for healthcare, aligning clinician
+              needs with patient empathy across a suite of diagnostic tools.
+            </p>
+            <ul>
+              <li>Introduced an adaptive triage tool now used in 400+ clinics.</li>
+              <li>Helped establish a design research guild to mentor new hires.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="projects" class="section">
+        <div class="section__header">
+          <span class="section__eyebrow">Selected Work</span>
+          <h2>Immersive, high-impact case studies</h2>
+        </div>
+        <div class="project-grid">
+          <article class="project-card glass">
+            <div class="project-card__meta">
+              <span class="pill">Mental Health</span>
+              <span class="project-card__year">2023</span>
+            </div>
+            <h3>Neuroadaptive Care Platform</h3>
+            <p>
+              A responsive platform harmonizing clinical data with human nuance to
+              reduce care gaps. Delivered a 37% drop in appointment no-shows.
+            </p>
+            <a class="button button--ghost" href="#" aria-label="View Neuroadaptive Care Platform case study"
+              >Read Case Study</a
+            >
+          </article>
+
+          <article class="project-card glass">
+            <div class="project-card__meta">
+              <span class="pill">Fintech</span>
+              <span class="project-card__year">2022</span>
+            </div>
+            <h3>Atlas Trust Console</h3>
+            <p>
+              A trust-first experience for cross-border investors. Integrates
+              real-time compliance with emotional assurance cues to build
+              confidence.
+            </p>
+            <a class="button button--ghost" href="#" aria-label="View Atlas Trust Console case study"
+              >Read Case Study</a
+            >
+          </article>
+
+          <article class="project-card glass">
+            <div class="project-card__meta">
+              <span class="pill">Healthcare</span>
+              <span class="project-card__year">2021</span>
+            </div>
+            <h3>Guided Recovery Companion</h3>
+            <p>
+              A conversational recovery assistant supporting patients between
+              appointments using adaptive tone and biometrics.
+            </p>
+            <a class="button button--ghost" href="#" aria-label="View Guided Recovery Companion case study"
+              >Read Case Study</a
+            >
+          </article>
+        </div>
+      </section>
+
+      <section id="testimonials" class="section">
+        <div class="section__header">
+          <span class="section__eyebrow">Testimonials</span>
+          <h2>Kind words from collaborators</h2>
+        </div>
+        <div class="testimonial-grid">
+          <figure class="testimonial glass">
+            <blockquote>
+              “Ivy balances evidence with emotion. Their guidance helped us build
+              a mental health app that patients trust with their story.”
+            </blockquote>
+            <figcaption>
+              <span aria-hidden="true">—</span> Dr. Maya Chen, Chief Medical Officer
+            </figcaption>
+          </figure>
+
+          <figure class="testimonial glass">
+            <blockquote>
+              “From research to storytelling, Ivy created a gravitational pull
+              around our product vision. The impact on activation speaks for
+              itself.”
+            </blockquote>
+            <figcaption>
+              <span aria-hidden="true">—</span> Samir Patel, VP of Product
+            </figcaption>
+          </figure>
+
+          <figure class="testimonial glass">
+            <blockquote>
+              “Working with Ivy is like having a calm, strategic compass. They
+              elevate every touchpoint with meticulous attention and humanity.”
+            </blockquote>
+            <figcaption>
+              <span aria-hidden="true">—</span> Nia Brooks, Head of Experience
+            </figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="contact" class="section section--split">
+        <div class="section__header">
+          <span class="section__eyebrow">Contact</span>
+          <h2>Let's co-create something meaningful</h2>
+        </div>
+        <form class="contact-form glass" aria-label="Contact form">
+          <div class="form-group">
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" placeholder="Your name" required />
+          </div>
+          <div class="form-group">
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" placeholder="you@example.com" required />
+          </div>
+          <div class="form-group">
+            <label for="message">Project Details</label>
+            <textarea
+              id="message"
+              name="message"
+              rows="4"
+              placeholder="Tell me about the impact you’re aiming for"
+              required
+            ></textarea>
+          </div>
+          <button class="button" type="submit">Send Message</button>
+        </form>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>© <span id="year"></span> Ivy Morrow. Designed with intention and joy.</p>
+      <div class="footer__links">
+        <a href="mailto:hello@ivymorrow.design">Email</a>
+        <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="https://dribbble.com" target="_blank" rel="noopener">Dribbble</a>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a new single-page portfolio with hero, about, experience, projects, testimonials, and contact sections
- add immersive liquid-glass themed styling, responsive layout, and light/dark theming support
- implement interactive enhancements including theme persistence, scroll-based nav highlighting, and a mobile menu

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6f29eea74833282cb9b3264d528b5